### PR TITLE
Add processing to shorten the test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ down:
 go-build: docker-start format
 	@$(go) build -o app
 test: docker-start format
-	@$(go) test -v
+	@$(go) test -v -cover
 format:
 	@goimports -w ./src
 docker-start:

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ go-build: docker-start format
 	@$(go) build -o app
 test: docker-start format
 	@$(go) test -v -cover
+test-short: docker-start format
+	@$(go) test -v -cover -short
 format:
 	@goimports -w ./src
 docker-start:

--- a/src/main_test.go
+++ b/src/main_test.go
@@ -133,6 +133,10 @@ func TestPostUser(t *testing.T) {
 }
 
 func TestGetCoordinates(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	dummyCoordinates, err := dummy.GetCoordinates(dummy.GET)
 	if err != nil {
 		log.Fatalln(err)
@@ -193,6 +197,10 @@ func imageToBase64(path string) (string, error) {
 }
 
 func TestPostCoordinate(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	dummyCoordinates, err := dummy.GetCoordinates(dummy.POST)
 	if err != nil {
 		log.Fatalln(err)


### PR DESCRIPTION
shortオプションでuser以外のモデルに関するテストを飛ばす。